### PR TITLE
스터디 글 상세 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import {Route, Routes} from "react-router-dom";
+import BoardInfo from "./pages/board/BoardInfo.jsx";
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    return (
+        <>
+            <Routes>
+                <Route path={`/board/:boardId`} element={<BoardInfo/>}/>
+            </Routes>
+        </>
+    )
 }
 
 export default App

--- a/src/api/board/getBoardInfo.js
+++ b/src/api/board/getBoardInfo.js
@@ -1,0 +1,13 @@
+async function getBoardInfo(boardId) {
+    console.log(boardId)
+    return fetch(`http://127.0.0.1:8080/board/${boardId}`)
+        .then((response) => {
+            if (!response.ok) {
+                console.log("백엔드 통신 에러");
+                throw new Error('백엔드 통신 에러');
+            }
+            return response.json();
+        })
+}
+
+export default getBoardInfo;

--- a/src/comopnents/board/BoardContent.jsx
+++ b/src/comopnents/board/BoardContent.jsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const BoardContent = ({content}) => {
+    return (
+        <BoardContentDiv>
+            {content}
+        </BoardContentDiv>
+    )
+}
+
+export default BoardContent;
+
+const BoardContentDiv = styled.div`
+    padding: 15px;
+`;

--- a/src/comopnents/board/BoardHeader.jsx
+++ b/src/comopnents/board/BoardHeader.jsx
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+import {formatDateTime} from "../../utils/DateTimeUtil.js";
+import {useNavigate} from "react-router-dom";
+
+const BoardHeader = ({boardId, title, created_at, updated_at, userId, nickname, commentCount, writerImgSrc, commentComponentRef}) => {
+    let nav = useNavigate();
+    const onClickWriterProfile = (userId) => {
+        nav(`/user/${userId}`);
+    }
+    const onClickCommentCountDiv = () => {
+        commentComponentRef.current?.scrollIntoView({behavior: "smooth", block: "end"});
+    }
+    return (
+        <BoardHeaderDiv>
+            <BoardHeaderInfoDIv>
+                <BoardHeaderTitle>{title}</BoardHeaderTitle>
+                <BoardHeaderSubTitle>
+                    <BoardWriterDiv onClick={() => onClickWriterProfile(userId)}><BoardWriterImg src={writerImgSrc}/> {nickname}</BoardWriterDiv>
+                    |<BoardCreatedDateDiv>{formatDateTime(created_at)}</BoardCreatedDateDiv>
+                </BoardHeaderSubTitle>
+            </BoardHeaderInfoDIv>
+            <CommentCountDiv onClick={onClickCommentCountDiv}>댓글 {commentCount}</CommentCountDiv>
+        </BoardHeaderDiv>
+    )
+}
+
+export default BoardHeader;
+
+const BoardHeaderDiv = styled.div`
+    display: flex;
+    flex-flow: row;
+    justify-content: space-between;
+    border-bottom: 1.5px solid #000000;
+    padding: 15px;
+`;
+
+const BoardHeaderInfoDIv = styled.div`
+    display: flex;
+    flex-flow: column;
+`;
+
+const BoardHeaderTitle = styled.div`
+    font-size: 30px;
+    font-weight: bold;
+`;
+
+const BoardHeaderSubTitle = styled.div`
+    display: flex;
+    flex-flow: row;
+`;
+
+const BoardWriterImg = styled.img`
+    display: flex;
+    align-items: center;
+    margin-right: 5px;
+    height: 20px;
+    border-radius: 15px;
+    border: 1px solid black;
+`;
+
+const BoardWriterDiv = styled.div`
+    display: flex;
+    align-items: center;
+    margin-left: 5px;
+    margin-right: 5px;
+    &:hover {
+        cursor: pointer;
+    }
+`;
+
+const BoardCreatedDateDiv = styled.div`
+    display: flex;
+    align-items: center;
+    margin-left: 5px;
+`;
+
+const CommentCountDiv = styled.div`
+    display: flex;
+    align-items: flex-end;
+    &:hover {
+        cursor: pointer;
+    }
+`;

--- a/src/comopnents/board/BoardTag.jsx
+++ b/src/comopnents/board/BoardTag.jsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+import {useNavigate} from "react-router-dom";
+
+const BoardTag = ({tagList}) => {
+    let nav = useNavigate();
+    const onClickTag = (tagId) => {
+        nav(`/tag/${tagId}`);
+    }
+    return (
+        <BoardTagDiv>
+            {
+                tagList.map((tag) => {
+                    return (<TagDiv onClick={() => onClickTag(tag.tagId)}>#{tag.tagName}</TagDiv>)
+                })
+            }
+        </BoardTagDiv>
+    )
+}
+
+export default BoardTag;
+
+const BoardTagDiv = styled.div`
+    display: flex;
+    flex-flow: row;
+    padding: 15px;
+    border-bottom: 2px solid #888888;
+`;
+
+const TagDiv = styled.div`
+    border: 2px solid #888888;
+    color: #20851f;
+    border-radius: 10px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
+    font-size: 15px;
+    margin-right: 5px;
+
+    &:hover {
+        cursor: pointer;
+    }
+`;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,9 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
+import {createRoot} from 'react-dom/client'
 import App from './App.jsx'
+import {BrowserRouter} from "react-router-dom";
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+    <BrowserRouter>
+        <App/>
+    </BrowserRouter>,
 )

--- a/src/pages/board/BoardInfo.jsx
+++ b/src/pages/board/BoardInfo.jsx
@@ -4,6 +4,7 @@ import getBoardInfo from "../../api/board/getBoardInfo.js";
 import BoardHeader from "../../comopnents/board/BoardHeader.jsx";
 import BoardContent from "../../comopnents/board/BoardContent.jsx";
 import BoardTag from "../../comopnents/board/BoardTag.jsx";
+import usePageTitle from "../../utils/usePageTitle.js";
 
 const callBoardInfoApi = (boardId, setBoardInfo) => {
     getBoardInfo(boardId).then((response) => {
@@ -45,6 +46,7 @@ const BoardInfo = () => {
     const [commentList, setCommentList] = useState(initCommentListData);
     const [tagList, setTagList] = useState(initTagListData);
     const commentComponentRef = useRef();
+    usePageTitle(`${boardInfo.title}`);
 
     useEffect(() => {
         callBoardInfoApi(boardId, setBoardInfo);

--- a/src/pages/board/BoardInfo.jsx
+++ b/src/pages/board/BoardInfo.jsx
@@ -1,0 +1,75 @@
+import {useParams} from "react-router-dom";
+import {useEffect, useRef, useState} from "react";
+import getBoardInfo from "../../api/board/getBoardInfo.js";
+import BoardHeader from "../../comopnents/board/BoardHeader.jsx";
+import BoardContent from "../../comopnents/board/BoardContent.jsx";
+import BoardTag from "../../comopnents/board/BoardTag.jsx";
+
+const callBoardInfoApi = (boardId, setBoardInfo) => {
+    getBoardInfo(boardId).then((response) => {
+        setBoardInfo(response)
+    });
+}
+
+const callBoardCommentApi = (boardId, setCommentList) => {
+    console.log(`board ${boardId}의 comment API 연결 요망`) // TODO board 의 comment API 연결 요망
+}
+
+const callBoardTagApi = (boardId, setTagList) => {
+    console.log(`board ${boardId}의 tag API 연결 요망`) // TODO board 의 tag API 연결 요망
+}
+
+const initBoardData = {
+    boardId: 0,
+    title: "",
+    content: "",
+    created_at: "",
+    updated_at: "",
+    userId: 0,
+    email: "",
+    nickname: "",
+};
+
+const initCommentListData = [{}, {}, {}]
+const initTagListData = [
+    {tagName: "figma", tagId: 1},
+    {tagName: "UI/UX", tagId: 2},
+    {tagName: "컴포넌트", tagId: 3},
+]
+
+const writerImgSrc = "https://cdn.pixabay.com/photo/2023/02/18/11/00/icon-7797704_1280.png"; // TODO 프로필 이미지 기능 추가
+
+const BoardInfo = () => {
+    const {boardId} = useParams();
+    const [boardInfo, setBoardInfo] = useState(initBoardData);
+    const [commentList, setCommentList] = useState(initCommentListData);
+    const [tagList, setTagList] = useState(initTagListData);
+    const commentComponentRef = useRef();
+
+    useEffect(() => {
+        callBoardInfoApi(boardId, setBoardInfo);
+        callBoardCommentApi(boardId, setCommentList);
+        callBoardTagApi(boardId, setTagList);
+    }, [boardId]);
+
+    return (
+        <>
+            <BoardHeader
+                boardId={boardInfo.boardId}
+                title={boardInfo.title}
+                created_at={boardInfo.created_at}
+                updated_at={boardInfo.updated_at}
+                userId={boardInfo.userId}
+                nickname={boardInfo.nickname}
+                commentCount={commentList.length}
+                writerImgSrc={writerImgSrc}
+                commentComponentRef={commentComponentRef}
+            />
+            <BoardContent content={boardInfo.content}/>
+            <BoardTag tagList={tagList}/>
+            <div ref={commentComponentRef}/>
+        </>
+    )
+}
+
+export default BoardInfo;

--- a/src/utils/DateTimeUtil.js
+++ b/src/utils/DateTimeUtil.js
@@ -1,0 +1,15 @@
+export function formatDateTime(isoString) {
+    // Date 객체로 파싱
+    const date = new Date(isoString);
+
+    // 각 부분 추출 및 두 자리수로 맞춤
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0'); // 월: 0부터 시작
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+
+    // 원하는 형식으로 조합
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}

--- a/src/utils/usePageTitle.js
+++ b/src/utils/usePageTitle.js
@@ -1,0 +1,10 @@
+import {useEffect} from "react";
+
+const usePageTitle = (title) => {
+    useEffect(() => {
+        const $title = document.getElementsByTagName("title")[0];
+        $title.innerText = title;
+    }, [title]);
+};
+
+export default usePageTitle;


### PR DESCRIPTION
## 작업 내용
- 스터디 글 상세 페이지 구현

## 연관된 이슈
- #2 

## 스크린샷
https://github.com/user-attachments/assets/6c52e42a-5e55-4768-a6a4-72a16af88a74

## 특이사항
- 게시글 상세 페이지에서 사용하는 게시글의 댓글, 태그 관련 API 와 연결이 필요합니다.
- 자바의 `LocalDateTime` 으로 받아오는 String 값을 피그마상의 형식으로 변환하는 `DateTimeUtil:formatDateTime` 메서드를 구현했습니다.
- 페이지 타이틀을 변경시키는 커스텀 훅(`usePageTitle`)을 구현했습니다.
