### PR TITLE
라우트 복구 및 라우트 상단에 여백 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import { Container } from "lucide-react";
 import Header from "./components/header/Header.jsx";
 import MyPage from "./components/auth/MyPage.jsx";
 import Home from "./components/HomPage.jsx";
+import EditBoard from "./components/board/EditBoard.jsx";
+import WriteBoard from "./components/board/WriteBoard.jsx";
 
 function App() {
   return (
@@ -16,12 +18,20 @@ function App() {
       <Header>
         <Container style={{ minHeight: "75vh" }}>studyMonster</Container>
       </Header>
+      <div style={{ paddingTop: "50px" }}></div>
       <Routes>
         <Route path="/auth/MyPage" element={<MyPage/>} />
         <Route path="/" element={<Home/>} />
+        <Route path="/study-groups" element={<StudyGroupList />} />
+        <Route path="/study-groups/new" element={<CreateStudyGroup />} />
+        <Route path={`/study-groups/:boardId`} element={<StudyGroupDetail />} />
+        <Route path="/boards/new" element={<WriteBoard />} />
+        <Route path={`/boards/:boardId`} element={<BoardInfo />} />
+        <Route path={`/boards/:boardId/edit`} element={<EditBoard />} />
       </Routes>
     </>
   );
 }
 
 export default App;
+

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -62,7 +62,7 @@ const Header = () => {
             style={{ display: "flex", alignItems: "center" }}
           >
             <SvgIcon />
-            <span style={{ fontWeight: "bold" }}>studyMonster</span>
+            <span style={{ fontWeight: "bold" }}>StudyMonster</span>
           </Navbar.Brand>
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Navbar.Collapse id="basic-navbar-nav">


### PR DESCRIPTION
## 작업 내용
- 최근 pr을 합치면서 App.jsx에 라우트가 삭제된걸 확인하고 복구했습니다.
  - https://github.com/LG-CNS-Mini-Team3/study-monster-front/commit/118a8ac1493d156bc9dd9614190abd22f957d6c7
- 헤더가 생기면서 페이지의 상단이 잘 안보이는 경우가 있어 상단에 여백 추가했습니다.

## 연관된 이슈
- #41 

## 스크린샷 (선택)
|상단에 여백 추가 전|상단에 여백 추가 후|
|---|---|
|<img width="757" alt="스크린샷 2025-05-23 오전 3 46 42" src="https://github.com/user-attachments/assets/620ed905-eabf-4c70-b9cf-560991fedb66" />|<img width="757" alt="스크린샷 2025-05-23 오전 3 46 58" src="https://github.com/user-attachments/assets/5da1eaa6-9be9-482d-b0c1-d8a8650ef0c9" />|

## 특이사항(선택)
> 스터디 그룹 목록 조회 디자인이 바뀐거 같아 확인부탁드립니다. @pjy2163 
