### PR TITLE
API 호출시 엑세스 토큰 헤더 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
         <Route path="/boards/new" element={<WriteBoard />} />
         <Route path={`/boards`} element={<BoardList />} />{" "}
         <Route path={`/boards/:boardId`} element={<BoardInfo />} />
-        <Route path={`/boards/:boardId/edit`} element={<EditBoard />} />
+        <Route path={`/boards/:boardId/update`} element={<EditBoard />} />
       </Routes>
     </>
   );

--- a/src/api/board/createBoard.js
+++ b/src/api/board/createBoard.js
@@ -5,6 +5,7 @@ const createBoard = async (boardData) => {
     const response = await fetch(`${API_BASE_URL}/boards`, {
       method: 'POST',
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(boardData),

--- a/src/api/board/deleteBoard.js
+++ b/src/api/board/deleteBoard.js
@@ -5,6 +5,7 @@ const deleteBoard = async (boardId) => {
     const response = await fetch(`${API_BASE_URL}/boards/${boardId}`, {
       method: 'DELETE',
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         'Content-Type': 'application/json',
       },
     });

--- a/src/api/board/getBoardAiFeedback.js
+++ b/src/api/board/getBoardAiFeedback.js
@@ -1,5 +1,12 @@
 async function getBoardAiFeedback(boardId) {
-    return fetch(`http://127.0.0.1:8080/boards/${boardId}/feedback`)
+    return fetch(
+        `http://127.0.0.1:8080/boards/${boardId}/feedback`,
+        {
+            headers: {
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        }
+    )
         .then((response) => {
             if (!response.ok) {
                 console.log("백엔드 통신 에러");

--- a/src/api/board/getBoardInfo.js
+++ b/src/api/board/getBoardInfo.js
@@ -1,6 +1,13 @@
 async function getBoardInfo(boardId) {
   console.log(boardId);
-  return fetch(`http://127.0.0.1:8080/boards/${boardId}`).then((response) => {
+  return fetch(
+      `http://127.0.0.1:8080/boards/${boardId}`,
+      {
+        headers: {
+            "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        }
+      }
+  ).then((response) => {
     if (!response.ok) {
       console.log("백엔드 통신 에러");
       throw new Error("백엔드 통신 에러");

--- a/src/api/board/getBoardTags.js
+++ b/src/api/board/getBoardTags.js
@@ -5,6 +5,7 @@ const getBoardTags = async (boardId) => {
     const response = await fetch(`${API_BASE_URL}/boards/${boardId}/tags`, {
       method: 'GET',
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         'Content-Type': 'application/json',
       },
     });

--- a/src/api/board/updateBoard.js
+++ b/src/api/board/updateBoard.js
@@ -6,6 +6,7 @@ const updateBoard = async (boardId, boardData) => {
     const response = await fetch(`${API_BASE_URL}/boards/${boardId}`, {
       method: 'PUT',
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(boardData),

--- a/src/api/bookmark/bookmark_api.js
+++ b/src/api/bookmark/bookmark_api.js
@@ -6,6 +6,7 @@ export const checkBookmark = async (body) => {
     const res = await fetch(`${API_BASE_URL}/check`, {
       method: "POST",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -27,6 +28,7 @@ export const addBookmark = async (body) => {
     const res = await fetch(`${API_BASE_URL}`, {
       method: "POST",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -46,6 +48,7 @@ export const removeBookmark = async (body) => {
     const res = await fetch(`${API_BASE_URL}`, {
       method: "DELETE",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -59,10 +62,13 @@ export const removeBookmark = async (body) => {
   }
 };
 
-export const getBookmark = async (userId) => {
+export const getBookmark = async (userId) => { // TODO API에러
   try {
     const res = await fetch(`${API_BASE_URL}/list/${userId}`, {
-      method: "GET"
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+      }
     });
 
     if (!res.ok) throw new Error("북마크 불러오기 실패");

--- a/src/api/comment/comment_api.js
+++ b/src/api/comment/comment_api.js
@@ -5,6 +5,7 @@ export const createComment = async (body) => {
     const res = await fetch(API_BASE_URL + "/add", {
       method: "post",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: body,
@@ -22,11 +23,15 @@ export const createComment = async (body) => {
   }
 };
 
-export const listComment = async (num) => {
+export const listComment = async (num) => { // TODO API에러
   try {
     const res = await fetch(API_BASE_URL + "/list/"+ num, {
-      method: "get"
+      method: "get",
+        headers: {
+          "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        }
     });
+      console.log(res);
     if (res.ok) {
       const data = await res.json();
       return data;
@@ -46,6 +51,7 @@ export const updateComment = async (body) => {
         const res = await fetch(API_BASE_URL + "/modify", {
             method: 'PUT',
             headers: {
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
                 'Content-Type': 'application/json',
             },
             body: body
@@ -73,6 +79,7 @@ export const deleteComment = async (body) => {
     const res = await fetch(API_BASE_URL + "/delete", {
       method: "delete",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: body

--- a/src/api/like/like_api.js
+++ b/src/api/like/like_api.js
@@ -1,6 +1,6 @@
 const API_BASE_URL = "http://localhost:8080/like";
 
-export const addLike = async (body) => {
+export const addLike = async (body) => { // TODO API에러
   try {
     const parsedBody = JSON.parse(body);
     if (hasLikedToday(parsedBody.user_id)) {
@@ -11,6 +11,7 @@ export const addLike = async (body) => {
     const res = await fetch(API_BASE_URL + "/add", {
       method: "post",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: body,
@@ -34,6 +35,7 @@ export const isUserLiked = async (body) => {
     const res = await fetch(API_BASE_URL + "/check", {
       method: "get",
       headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "Content-Type": "application/json",
       },
       body: body,
@@ -44,10 +46,13 @@ export const isUserLiked = async (body) => {
   }
 };
 
-export const getLikeCount = async (boardId) => {
+export const getLikeCount = async (boardId) => {  // TODO API에러
   try {
     const res = await fetch(API_BASE_URL + "/get/"+ boardId, {
       method: "get",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+      }
     });
     if (res.ok) {
       const data = await res.json();

--- a/src/components/Caption/Comment.jsx
+++ b/src/components/Caption/Comment.jsx
@@ -10,7 +10,7 @@ const Comment = ({userId, boardId}) => {
 
   useEffect(() => {
     async function temp() {
-      const data = await listComment(boardId);
+      // const data = await listComment(boardId); // TODO API 에러
       setComments(data);
     }
     temp();

--- a/src/components/bookmark/BookmarkList.jsx
+++ b/src/components/bookmark/BookmarkList.jsx
@@ -8,7 +8,7 @@ const BookmarkList = ({userId}) => {
 
     useEffect(() => {
         async function temp() {
-              const data = await getBookmark(userId);
+              // const data = await getBookmark(userId); //TODO API에러
               console.log(data)
               setBookmarks(data);
             }

--- a/src/pages/board/BoardInfo.jsx
+++ b/src/pages/board/BoardInfo.jsx
@@ -12,6 +12,7 @@ import Comment from "../../components/Caption/Comment.jsx";
 import BookmarkList from "../../components/bookmark/BookmarkList.jsx";
 import { listComment } from "../../api/comment/comment_api.js";
 import { fetchUser } from "../../api/user/AuthApi.jsx";
+import deleteBoard from "../../api/board/deleteBoard.js";
 
 const callBoardInfoApi = (boardId, setBoardInfo) => {
     getBoardInfo(boardId).then((response) => {
@@ -21,7 +22,7 @@ const callBoardInfoApi = (boardId, setBoardInfo) => {
 
 const callBoardCommentApi = async (boardId, setCommentList) => {
     console.log(`board ${boardId}의 comment API 연결 요망`); // TODO board 의 comment API 연결 요망
-    const comments = await listComment(boardId)
+    // const comments = await listComment(boardId) // TODO API 에러
     setCommentList(comments)
 };
 

--- a/src/pages/board/BoardList.jsx
+++ b/src/pages/board/BoardList.jsx
@@ -19,7 +19,12 @@ const BoardList = () => {
             type
         };
 
-        axios.get(`http://localhost:8080/boards`, { params })
+        axios.get(`http://localhost:8080/boards`, {
+            params,
+            headers: {
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        })
             .then(res => {
                 if (res.data && Array.isArray(res.data.content)) {
                     setBoards(res.data.content);

--- a/src/pages/board/Paging.jsx
+++ b/src/pages/board/Paging.jsx
@@ -8,7 +8,10 @@ const Paging = () => {
 
     const fetchBoards = (pageNum) => {
         axios.get(`http://localhost:8080/boards`, {
-            params: { page: pageNum, size: 5 }
+            params: { page: pageNum, size: 5 },
+            headers: {
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
         })
             .then(res => {
                 setBoards(res.data.content);


### PR DESCRIPTION
## 작업 내용
API 호출시 엑세스 토큰 헤더 추가

정상적인 동작이 확인된 API 목록
- 게시글 생성
- 게시글 삭제
- 게시글 피드백 생성
- 게시글 상세 정보 조회
- 게시글, 태그 수정
  - 페이지 navigate 주소와 route 주소가 상이하여 path를 동기화 시켰습니다. `/boards/:boardId/edit` -> `/boards/:boardId/update` 수정
- 게시글 목록

## 연관된 이슈
- #47

## 특이사항(선택) 
@kaebalsaebal 님께서 작업하신 부분들이 대부분 API의 오류가 발생하여 제가 찾으려고 노력해봤으나, 원인을 찾기 어려워 구현하신분이 직접 해결하시는것이 좋을것 같습니다. 새로 이슈를 생성하거나 브랜치를 생성해서 작업 부탁드립니다.
- 북마크 API 전체 -> 알수없는 에러
- 댓글 API 전체 -> 알수없는 에러
- 추천, 비추천 -> 알수없는 에러
